### PR TITLE
Highscore screen appearing on level not finished

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -425,6 +425,8 @@ async def main_game():
                 "bomberman" in state
                 and "exit" in state
                 and state["bomberman"] == state["exit"]
+                and "enemies" in state
+                and state["enemies"] == []
             )
         ):
             highscores = newgame_json["highscores"]


### PR DESCRIPTION
If the playable character passes the exit door while enemies are alive, the game keeps going yet there is a highscore screen stuck on screen. You can still play, and walking over passable areas reveals the underlying path, yet it shouldn't appear as it blocks a good portion of the screen. 